### PR TITLE
fix: fix logical inconsistency in log entry formatting in index.html

### DIFF
--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -54,7 +54,7 @@
          linera.onNotification(notification => {
              let newBlock = notification.reason.NewBlock;
              if (!newBlock) return;
-             addLogEntry(`${newBlock.height}: ${newBlock.hash.padStart(5)}`);
+             addLogEntry(`${newBlock.height}: ${newBlock.hash.slice(0, 5)}`);
              updateCount();
          });
          linera.load().then(updateCount);


### PR DESCRIPTION
I noticed a logical inconsistency in the log entry formatting. The current code uses `padStart(5)` on `newBlock.hash`, which doesn't make sense for cryptographic hashes as they are typically much longer than 5 characters.  

To address this, I replaced `padStart(5)` with `slice(0, 5)` to ensure only the first 5 characters of the hash are displayed. This change aligns with the intended behavior of showing a concise representation of the hash.  

```javascript
addLogEntry(`${newBlock.height}: ${newBlock.hash.slice(0, 5)}`);
```  

This adjustment ensures the log entries are both meaningful and consistent.