### PR TITLE
Bump `linera-protocol`

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -66,6 +66,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
+name = "alloy-primitives"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hashbrown 0.15.2",
+ "indexmap 2.6.0",
+ "itoa",
+ "paste",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +798,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1537,6 +1576,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1568,6 +1608,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "http"
@@ -2047,6 +2090,7 @@ dependencies = [
 name = "linera-base"
 version = "0.14.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "async-graphql",
  "async-graphql-derive",
@@ -2059,7 +2103,6 @@ dependencies = [
  "custom_debug_derive",
  "ed25519-dalek",
  "futures",
- "generic-array",
  "getrandom",
  "hex",
  "is-terminal",
@@ -2072,7 +2115,6 @@ dependencies = [
  "serde-name",
  "serde_bytes",
  "serde_json",
- "sha3",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2848,6 +2890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3139,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.6.0",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3287,15 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3441,6 +3512,26 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "proptest",
+ "rand",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
@@ -4083,6 +4174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4555,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -50,7 +50,7 @@ features = ["web", "wasmer"]
 
 [dependencies.linera-execution]
 path = "../linera-protocol/linera-execution"
-features = ["web", "wasmer", "test"]
+features = ["web", "wasmer"]
 
 [dependencies.linera-rpc]
 path = "../linera-protocol/linera-rpc"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -56,6 +56,8 @@ pub const OPTIONS: ClientOptions = ClientOptions {
     blanket_message_policy: linera_core::client::BlanketMessagePolicy::Accept,
     restrict_chain_ids_to: None,
     long_lived_services: false,
+    blob_download_timeout: std::time::Duration::from_millis(1000),
+    grace_period: linera_core::DEFAULT_GRACE_PERIOD,
 
     // TODO(linera-protocol#2944): separate these out from the
     // `ClientOptions` struct, since they apply only to the CLI/native
@@ -257,67 +259,22 @@ impl Frontend {
         query: &str,
     ) -> Result<String, JsError> {
         let chain_client = self.0.default_chain_client().await?;
-        let response = chain_client
+        let linera_execution::QueryOutcome {
+            response: linera_execution::QueryResponse::User(response),
+            operations,
+        } = chain_client
             .query_application(linera_execution::Query::User {
                 application_id: application_id.parse()?,
                 bytes: query.as_bytes().to_vec(),
             })
-            .await?;
-        let linera_execution::Response::User(response) = response else {
-            panic!("system response to user query")
-        };
-        Ok(String::from_utf8(response)?)
-    }
-
-    /// Mutate an application's state with the given mutation.
-    ///
-    /// # Errors
-    /// If the application ID or mutation is invalid.
-    ///
-    /// # Panics
-    /// If the response from the service is not a GraphQL response
-    /// containing operations to execute.
-    #[wasm_bindgen]
-    // TODO(linera-protocol#2911) this function assumes GraphQL service output
-    pub async fn mutate_application(
-        &self,
-        application_id: &str,
-        mutation: &str,
-    ) -> Result<(), JsError> {
-        fn array_to_bytes(array: &[serde_json::Value]) -> Vec<u8> {
-            array
-                .iter()
-                .map(|value| value.as_u64().unwrap().try_into().unwrap())
-                .collect()
-        }
-
-        let chain_client = self.0.default_chain_client().await?;
-        let application_id = application_id.parse()?;
-        let response = chain_client
-            .query_application(linera_execution::Query::User {
-                application_id,
-                bytes: mutation.as_bytes().to_vec(),
-            })
-            .await?;
-        let linera_execution::Response::User(response) = response else {
-            panic!("system response to user query")
-        };
-        let response: serde_json::Value = serde_json::from_slice(&response)?;
-        let data = &response["data"];
-        tracing::info!("data: {data:?}");
-        let operations: Vec<_> = data
-            .as_object()
-            .unwrap()
-            .values()
-            .map(|value| linera_execution::Operation::User {
-                application_id,
-                bytes: array_to_bytes(value.as_array().unwrap()),
-            })
-            .collect();
+            .await?
+            else {
+                panic!("system response to user query")
+            };
 
         let _hash = loop {
             use linera_core::data_types::ClientOutcome::{Committed, WaitForTimeout};
-            let timeout = match chain_client.execute_operations(operations.clone()).await? {
+            let timeout = match chain_client.execute_operations(operations.clone(), vec![]).await? {
                 Committed(certificate) => break certificate.value().hash(),
                 WaitForTimeout(timeout) => timeout,
             };
@@ -325,7 +282,7 @@ impl Frontend {
             linera_client::util::wait_for_next_round(&mut stream, timeout).await;
         };
 
-        Ok(())
+        Ok(String::from_utf8(response)?)
     }
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -268,13 +268,16 @@ impl Frontend {
                 bytes: query.as_bytes().to_vec(),
             })
             .await?
-            else {
-                panic!("system response to user query")
-            };
+        else {
+            panic!("system response to user query")
+        };
 
         let _hash = loop {
             use linera_core::data_types::ClientOutcome::{Committed, WaitForTimeout};
-            let timeout = match chain_client.execute_operations(operations.clone(), vec![]).await? {
+            let timeout = match chain_client
+                .execute_operations(operations.clone(), vec![])
+                .await?
+            {
                 Committed(certificate) => break certificate.value().hash(),
                 WaitForTimeout(timeout) => timeout,
             };

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -31,7 +31,7 @@
 
      async function incrementCount() {
          await linera.callClientFunction(
-             'mutate_application',
+             'query_application',
              COUNTER_APP_ID,
              '{ "query": "mutation { increment(value: 1) }" }',
          );


### PR DESCRIPTION
Removes the need for `mutate_application`, as operations are now returned from application queries directly.